### PR TITLE
Fix compiling with Visual Studio 2015 - exceptions.hpp is no longer necessary

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -54,7 +54,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/type_traits.hpp>
 #include <lua.hpp>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #   include "misc/exception.hpp"
 #endif
 

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1303,14 +1303,14 @@ private:
     // this function calls what is on the top of the stack and removes it (just like lua_call)
     // if an exception is triggered, the top of the stack will be removed anyway
     template<typename TReturnType, typename... TParameters>
-    static auto call(lua_State* state, PushedObject toCall, TParameters&&... input)
+    static auto call(lua_State* state, PushedObject toCall, const TParameters&&... input)
         -> TReturnType
     {
         typedef typename Tupleizer<TReturnType>::type
             RealReturnType;
         
         // we push the parameters on the stack
-        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::make_tuple(std::forward<TParameters>(input)...));
+        auto inArguments = Pusher<std::tuple<const TParameters...>>::push(state, std::make_tuple(std::forward<const TParameters>(input)...));
 
         // 
         const int outArgumentsCount = std::tuple_size<RealReturnType>::value;
@@ -1806,10 +1806,10 @@ template<typename TRetValue, typename... TParams>
 class LuaContext::LuaFunctionCaller<TRetValue (TParams...)>
 {
 public:
-    TRetValue operator()(TParams&&... params) const
+    TRetValue operator()(const TParams&&... params) const
     {
         auto obj = valueHolder->pop();
-        return call<TRetValue>(state, std::move(obj), std::forward<TParams>(params)...);
+        return LuaContext::call<TRetValue>(state, std::move(obj), std::forward<const typename std::remove_reference<TParams>::type>(params)...);
     }
 
 private:

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -147,6 +147,15 @@ public:
     }
     
     /**
+     * Be careful, don't break it.
+     * (Allows loading other libraries, etc.)
+     */
+    lua_State* state() noexcept
+    {
+        return mState;
+    }
+    
+    /**
      * Thrown when an error happens during execution of lua code (like not enough parameters for a function)
      */
     class ExecutionErrorException : public std::runtime_error

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -2483,10 +2483,11 @@ struct LuaContext::Reader<std::string>
     static auto read(lua_State* state, int index)
         -> boost::optional<std::string>
     {
-        const auto val = lua_tostring(state, index);
+        size_t length = 0;
+        const auto val = lua_tolstring(state, index, &length);
         if (val == 0)
             return boost::none;
-        return std::string(val);
+        return std::string(val, length);
     }
 };
 

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -724,7 +724,7 @@ private:
     /*                     MISC                       */
     /**************************************************/
     // type used as a tag
-    template<typename T>
+    template <typename... Tn>
     struct tag {};
 
     // tag for "the registry"
@@ -1612,13 +1612,13 @@ private:
      * This functions reads multiple values starting at "index" and passes them to the callback
      */
     template<typename TRetValue, typename TCallback>
-    static auto readIntoFunction(lua_State* state, tag<TRetValue>, TCallback&& callback, int index)
+    static auto readIntoFunction(lua_State* state, tag<TRetValue>, TCallback&& callback, int index, tag<>)
         -> TRetValue
     {
         return callback();
     }
     template<typename TRetValue, typename TCallback, typename TFirstType, typename... TTypes>
-    static auto readIntoFunction(lua_State* state, tag<TRetValue> retValueTag, TCallback&& callback, int index, tag<TFirstType>, tag<TTypes>... othersTags)
+    static auto readIntoFunction(lua_State* state, tag<TRetValue> retValueTag, TCallback&& callback, int index, tag<TFirstType, TTypes...>)
         -> typename std::enable_if<IsOptional<TFirstType>::value, TRetValue>::type
     {
         if (index >= 0) {
@@ -1631,11 +1631,10 @@ private:
             throw WrongTypeException(lua_typename(state, index), typeid(TFirstType));
 
         Binder<TCallback, const TFirstType&> binder{ callback, *firstElem };
-        return readIntoFunction(state, retValueTag, binder, index + 1, othersTags...);
+        return readIntoFunction(state, retValueTag, binder, index + 1, tag<TTypes...>());
     }
-    template<typename TRetValue, typename TCallback, typename TFirstType, typename... TTypes>
-    static auto readIntoFunction(lua_State* state, tag<TRetValue> retValueTag, TCallback&& callback, int index, tag<TFirstType>, tag<TTypes>... othersTags)
-        -> typename std::enable_if<!IsOptional<TFirstType>::value, TRetValue>::type
+    template<typename TRetValue, typename TCallback, typename TFirstType, typename... TTypes, typename = typename std::enable_if<!IsOptional<TFirstType>::value, TRetValue>::type>
+    static TRetValue readIntoFunction(lua_State* state, tag<TRetValue> retValueTag, TCallback&& callback, int index, tag<TFirstType, TTypes...>)
     {
         if (index >= 0)
             throw std::logic_error("Wrong number of parameters");
@@ -1645,7 +1644,7 @@ private:
             throw WrongTypeException(lua_typename(state, index), typeid(TFirstType));
 
         Binder<TCallback, const TFirstType&> binder{ callback, *firstElem };
-        return readIntoFunction(state, retValueTag, binder, index + 1, othersTags...);
+        return readIntoFunction(state, retValueTag, binder, index + 1, tag<TTypes...>());
     }
 
 
@@ -2311,14 +2310,14 @@ private:
         // pushing the result on the stack and returning number of pushed elements
         typedef Pusher<typename std::decay<TReturnType>::type>
             P;
-        return P::push(state, readIntoFunction(state, tag<TReturnType>{}, toCall, -argumentsCount, tag<TParameters>{}...));
+        return P::push(state, readIntoFunction(state, tag<TReturnType>{}, toCall, -argumentsCount, tag<TParameters...>{}));
     }
     
     template<typename TFunctionObject>
     static auto callback2(lua_State* state, TFunctionObject&& toCall, int argumentsCount)
         -> typename std::enable_if<std::is_void<TReturnType>::value && !std::is_void<TFunctionObject>::value, PushedObject>::type
     {
-        readIntoFunction(state, tag<TReturnType>{}, toCall, -argumentsCount, tag<TParameters>{}...);
+        readIntoFunction(state, tag<TReturnType>{}, toCall, -argumentsCount, tag<TParameters...>{});
         return PushedObject{state, 0};
     }
 };

--- a/include/misc/exception.hpp
+++ b/include/misc/exception.hpp
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #   define EXCEPTION_HPP_NORETURN_MACRO [[noreturn]]
 #endif
-
+#if 0
 namespace std {
     class nested_exception {
     public:
@@ -80,5 +80,5 @@ namespace std {
         if (ptr) ptr->rethrow_nested();
     }
 }
-
+#endif
 #endif


### PR DESCRIPTION
Not sure exactly what version of VS this changed, but I'm guessing 2015.
