### PR TITLE
Update LuaContext.hpp to not include misc/exception.hpp in Visual Studio 14.0 (2015)

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -55,7 +55,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <lua.hpp>
 
 #ifdef _MSC_VER
-#   include "misc/exception.hpp"
+#   if _MSC_VER <= 1800
+#       include "misc/exception.hpp"
+#   endif
 #endif
 
 #ifdef __GNUC__

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -54,10 +54,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/type_traits.hpp>
 #include <lua.hpp>
 
-#ifdef _MSC_VER
-#   if _MSC_VER <= 1800
-#       include "misc/exception.hpp"
-#   endif
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#   include "misc/exception.hpp"
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
Currently, LuaContext.hpp always includes the header file "misc/exception.hpp" if the compiler is MSVC++. This causes compilation errors in VS 14.0, since these functions are already defined in the standard library. Hence, a check against the version number is required.
