### PR TITLE
Add constructor to support pre-exising Lua state.

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -103,6 +103,15 @@ public:
     }
 
     /**
+     * Constructor to hook into an existing Lua state.
+     *
+     * @param L exisitng Lua state
+     */
+    explicit LuaContext(lua_State* L) : mState(L)
+    {
+    }
+
+    /**
      * Move constructor
      */
     LuaContext(LuaContext&& s) :


### PR DESCRIPTION
A simple change to allow for the creation of a `LuaContext` attached to a pre-existing, pre-configured, Lua state.

My specific use case is a game engine ([Uho3D](https://github.com/urho3d/Urho3D)) that already has it's own Lua subsystem, which I want to hook into.