### PR TITLE
Support `Pusher` and `Reader` for `unordered_map` with `Hash` param

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1971,12 +1971,12 @@ struct LuaContext::Pusher<std::map<TKey,TValue>> {
 };
 
 // unordered_maps
-template<typename TKey, typename TValue>
-struct LuaContext::Pusher<std::unordered_map<TKey,TValue>> {
+template<typename TKey, typename TValue, typename THasher>
+struct LuaContext::Pusher<std::unordered_map<TKey,TValue,THasher>> {
     static const int minSize = 1;
     static const int maxSize = 1;
 
-    static PushedObject push(lua_State* state, const std::unordered_map<TKey,TValue>& value) noexcept {
+    static PushedObject push(lua_State* state, const std::unordered_map<TKey,TValue,THasher>& value) noexcept {
         static_assert(Pusher<typename std::decay<TKey>::type>::minSize == 1 && Pusher<typename std::decay<TKey>::type>::maxSize == 1, "Can't push multiple elements for a table key");
         static_assert(Pusher<typename std::decay<TValue>::type>::minSize == 1 && Pusher<typename std::decay<TValue>::type>::maxSize == 1, "Can't push multiple elements for a table value");
         
@@ -2616,16 +2616,16 @@ struct LuaContext::Reader<std::map<TKey,TValue>>
 };
 
 // unordered_map
-template<typename TKey, typename TValue>
-struct LuaContext::Reader<std::unordered_map<TKey,TValue>>
+template<typename TKey, typename TValue, typename THasher>
+struct LuaContext::Reader<std::unordered_map<TKey,TValue,THasher>>
 {
     static auto read(lua_State* state, int index)
-        -> boost::optional<std::unordered_map<TKey,TValue>>
+        -> boost::optional<std::unordered_map<TKey,TValue,THasher>>
     {
         if (!lua_istable(state, index))
             return boost::none;
 
-        std::unordered_map<TKey,TValue> result;
+        std::unordered_map<TKey,TValue,THasher> result;
 
         // we traverse the table at the top of the stack
         lua_pushnil(state);     // first key


### PR DESCRIPTION
* If a `Hash` template parameter is used when constructing a
`std::unordered_map` (which is required for `boost::variant` keys), then
the `Pusher` and `Reader` template parameter deduction fails, and we
revert to assuming a simple `userdata` pointer.
* This means we cannot read and write a `std::unordered_map` that has `boost::variant` keys as a Lua
table.
* So simply add the missing `Hasher` template param to the `Pusher` and `Reader`
for `std::unordered_map`.