### PR TITLE
Use the correct index when storing a reference in the registry

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1636,9 +1636,9 @@ private:
     /**************************************************/
     /*                   UTILITIES                    */
     /**************************************************/
-    // structure that will ensure that a certain is stored somewhere in the registry
+    // structure that will ensure that a certain value is stored somewhere in the registry
     struct ValueInRegistry {
-        // this constructor will clone and hold the value at the top of the stack in the registry
+        // this constructor will clone and hold the value at the specified index (or by default at the top of the stack) in the registry
         ValueInRegistry(lua_State* lua, int index=-1) : lua{lua}
         {
             lua_pushlightuserdata(lua, this);

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1639,10 +1639,10 @@ private:
     // structure that will ensure that a certain is stored somewhere in the registry
     struct ValueInRegistry {
         // this constructor will clone and hold the value at the top of the stack in the registry
-        ValueInRegistry(lua_State* lua) : lua{lua}
+        ValueInRegistry(lua_State* lua, int index=-1) : lua{lua}
         {
             lua_pushlightuserdata(lua, this);
-            lua_pushvalue(lua, -2);
+            lua_pushvalue(lua, -1 + index);
             lua_settable(lua, LUA_REGISTRYINDEX);
         }
         
@@ -1818,8 +1818,8 @@ private:
 
 private:
     friend LuaContext;
-    explicit LuaFunctionCaller(lua_State* state) :
-        valueHolder(std::make_shared<ValueInRegistry>(state)),
+    explicit LuaFunctionCaller(lua_State* state, int index) :
+        valueHolder(std::make_shared<ValueInRegistry>(state, index)),
         state(state)
     {}
 };
@@ -2518,7 +2518,7 @@ struct LuaContext::Reader<LuaContext::LuaFunctionCaller<TRetValue (TParameters..
     {
         if (lua_isfunction(state, index) == 0 && lua_isuserdata(state, index) == 0)
             return boost::none;
-        return ReturnType(state);
+        return ReturnType(state, index);
     }
 };
 

--- a/tests/functions_write.cpp
+++ b/tests/functions_write.cpp
@@ -217,3 +217,25 @@ TEST(FunctionsWrite, ExecuteLuaFromWithinCallback) {
 
     context.executeCode("exec(\"x\")");
 }
+
+TEST(FunctionsWrite, CallbackNotLastArgument) {
+    LuaContext context;
+
+    struct Foo {
+        static int a(void)
+        {
+            return 1;
+        }
+
+        static int b(void)
+        {
+            return 2;
+        }
+    };
+
+    context.writeFunction("foo", [](std::function<int(void)> a, std::function<int(void)> b) {
+        return a();
+    });
+
+    EXPECT_EQ(1, context.executeCode<int>("function a() return 1 end function b() return 2 end return foo(a,b)"));
+}


### PR DESCRIPTION
Upstreamed from PowerDNS.