### PR TITLE
forward arguments through tuple, preserving rvalue-references

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1310,7 +1310,7 @@ private:
             RealReturnType;
         
         // we push the parameters on the stack
-        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::make_tuple(std::forward<TParameters>(input)...));
+        auto inArguments = Pusher<std::tuple<TParameters&&...>>::push(state, std::forward_as_tuple(std::forward<TParameters>(input)...));
 
         // 
         const int outArgumentsCount = std::tuple_size<RealReturnType>::value;

--- a/tests/functions_read.cpp
+++ b/tests/functions_read.cpp
@@ -69,3 +69,15 @@ TEST(FunctionsRead, CallLuaFunctionFromWithinCallback) {
         execute("test")
     )");
 }
+
+TEST(FunctionsRead, LuaFunctionsPassUniquePtr) {
+    struct Foo {
+    };
+
+    LuaContext context;
+
+    context.executeCode("f = function(x) return 4; end");
+    const auto f = context.readVariable<std::function<int (std::unique_ptr<Foo>)>>("f");
+
+    EXPECT_EQ(4, f(std::unique_ptr<Foo>(new Foo())));
+}


### PR DESCRIPTION
also add unit test to make sure noncopyable-but-movable values can be moved to lua.

This conflicts with #23 - and I don't know if it fixes the original problem behind that one (https://github.com/PowerDNS/pdns/issues/3552)