### PR TITLE
Fixed bug that confuses lua_next.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(tests
 	tests/movable.cpp
 	tests/metatables.cpp
 	tests/threads.cpp
+	tests/maps.cpp
 )
 
 target_link_libraries(tests

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -2592,11 +2592,21 @@ struct LuaContext::Reader<std::string>
     static auto read(lua_State* state, int index)
         -> boost::optional<std::string>
     {
+        std::string result;
+
+        // lua_tolstring might convert the variable that would confuse lua_next, so we
+        //   make a copy of the variable.
+        lua_pushvalue(state, index);
+
         size_t len;
-        const auto val = lua_tolstring(state, index, &len);
-        if (val == 0)
-            return boost::none;
-        return std::string(val, len);
+        const auto val = lua_tolstring(state, -1, &len);
+
+        if (val != 0)
+          result.assign(val, len);
+
+        lua_pop(state, 1);
+
+        return val != 0 ? boost::optional<std::string>{ std::move(result) } : boost::none;
     }
 };
 

--- a/tests/maps.cpp
+++ b/tests/maps.cpp
@@ -1,0 +1,48 @@
+#include <LuaContext.hpp>
+#include <gtest/gtest.h>
+
+TEST(Maps, MapString) {
+    LuaContext context;
+
+    using map_type = std::map<std::string, int>;
+
+    map_type a{{"foo", 1}, {"bar", 2}};
+    context.writeVariable("a", a);
+
+    const auto b = context.readVariable<map_type>("a");
+    EXPECT_EQ(1, b.at("foo"));
+    EXPECT_EQ(2, b.at("bar"));
+}
+
+TEST(Maps, UnorderedMapString) {
+    LuaContext context;
+
+    using map_type = std::unordered_map<std::string, int>;
+
+    map_type a{{"foo", 1}, {"bar", 2}};
+    context.writeVariable("a", a);
+
+    const auto b = context.readVariable<map_type>("a");
+    EXPECT_EQ(1, b.at("foo"));
+    EXPECT_EQ(2, b.at("bar"));
+}
+
+TEST(Maps, MapVariant) {
+    LuaContext context;
+
+    // if `std::string` would come first, any `int` key would be converted
+    // to `std::string` when reading.
+    using map_type = std::map<boost::variant<int, std::string>, int>;
+
+    map_type a{{"foo", 1}, {2, 3}};
+    EXPECT_EQ(1, a.at("foo"));
+    EXPECT_EQ(3, a.at(2));
+
+    context.writeVariable("a", a);
+    EXPECT_EQ(1, context.readVariable<int>("a", "foo"));
+    EXPECT_EQ(3, context.readVariable<int>("a", 2));
+
+    const auto b = context.readVariable<map_type>("a");
+    EXPECT_EQ(1, b.at("foo"));
+    EXPECT_EQ(3, b.at(2));
+}


### PR DESCRIPTION
I fixed the problem that I mentioned in #37.

According to the manual:

> If the value is a number, then lua_tolstring also changes the actual
> value in the stack to a string. (This change confuses lua_next when
> lua_tolstring is applied to keys during a table traversal.)

That leads to potential problems while reading maps which keys are
std::string or boost::variant<std::string, ...> and the lua table key is numeric.

If you decide to merge one of these PRs, I can rebase the other one.
Just let me know.