### PR TITLE
Added capability to read std::complex from {re=..., im=...}

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <complex>
 #include <cstring>
 #include <functional>
 #include <limits>
@@ -2567,6 +2568,23 @@ struct LuaContext::Reader<
             return static_cast<TType>(lua_tonumber(state, index));
 
 #       endif
+    }
+};
+
+// std::complex
+template<typename NumberType>
+struct LuaContext::Reader<
+            std::complex<NumberType>,
+            typename std::enable_if<std::is_floating_point<NumberType>::value>::type
+        >
+{
+    static auto read(lua_State* state, int index)
+        -> boost::optional<std::complex<NumberType>>
+    {
+        auto val = LuaContext::Reader<std::map<std::string, NumberType>>::read(state, index);
+        if(!val) return boost::none;
+
+        return std::complex{ val.get().count("re") ? val.get()["re"] : 0, val.get().count("im") ? val.get()["im"] : 0 };
     }
 };
 

--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -2584,7 +2584,7 @@ struct LuaContext::Reader<
         auto val = LuaContext::Reader<std::map<std::string, NumberType>>::read(state, index);
         if(!val) return boost::none;
 
-        return std::complex{ val.get().count("re") ? val.get()["re"] : 0, val.get().count("im") ? val.get()["im"] : 0 };
+        return std::complex<NumberType>{ val.get().count("re") ? val.get()["re"] : 0, val.get().count("im") ? val.get()["im"] : 0 };
     }
 };
 


### PR DESCRIPTION
This change enables functions taking std::complex arguments to be called form within lua by `f({re=0, im=1})`.