### PR TITLE
fix typo at setting writeFunction for dynamic member variable

### DIFF
--- a/include/LuaContext.hpp
+++ b/include/LuaContext.hpp
@@ -1285,12 +1285,12 @@ private:
             writeFunction_(object, name, value);
         });
         
-        setTable<void (TObject*, std::string, TVarType)>(mState, Registry, &typeid(TObject*), 2, [writeFunction_](TObject* object, const std::string& name, const TVarType& value) {
+        setTable<void (TObject*, std::string, TVarType)>(mState, Registry, &typeid(TObject*), 5, [writeFunction_](TObject* object, const std::string& name, const TVarType& value) {
             assert(object);
             writeFunction_(*object, name, value);
         });
         
-        setTable<void (std::shared_ptr<TObject>, std::string, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 2, [writeFunction_](const std::shared_ptr<TObject>& object, const std::string& name, const TVarType& value) {
+        setTable<void (std::shared_ptr<TObject>, std::string, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 5, [writeFunction_](const std::shared_ptr<TObject>& object, const std::string& name, const TVarType& value) {
             assert(object);
             writeFunction_(*object, name, value);
         });

--- a/tests/custom_types.cpp
+++ b/tests/custom_types.cpp
@@ -273,6 +273,12 @@ TEST(CustomTypes, GenericMembers) {
     EXPECT_EQ(5, context.executeCode<int>("return obj.foo"));
     context.executeCode("obj.bar = 18");
     EXPECT_EQ(18, context.executeCode<int>("return obj.bowl"));
+
+    Object obj;
+    context.writeVariable("objptr", &obj);
+    EXPECT_EQ(5, context.executeCode<int>("return objptr.foo"));
+    EXPECT_NO_THROW(context.executeCode("objptr.bar = 18"));
+    EXPECT_EQ(18, context.executeCode<int>("return objptr.bowl"));
 }
 
 TEST(CustomTypes, CopiesCheckReadWrite) {


### PR DESCRIPTION
sub-id for writeFunction of dynamic variable is 5 not 2 in TypeRegistration